### PR TITLE
add sysfs entry pwm_enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a hwmon Linux kernel driver supporting the following Aquacomputer device
 | Farbwerk 360 |          5.18          |                 Temperature sensors                 |  MCF51JU128VHS  |
 |   Farbwerk   |          5.19          |                 Temperature sensors                 |        ?        |
 |     Octo     |          5.19          | Temperature and fan sensors, direct fan PWM control |  MCF51JU128VLH  |
-|    Quadro    |     Available here     | Temperature and fan sensors, direct fan PWM control |  MCF51JU128VHS  |
+|    Quadro    |     Available here     | Temperature, flow and fan sensors, direct fan PWM control |  MCF51JU128VHS  |
 
 The above table shows what devices this driver supports and starting from which kernel version, if applicable. Microcontrollers are noted for general reference, as this driver only communicates through HID reports and does not interact with the device CPU & electronics directly.
 
@@ -68,7 +68,32 @@ Fan 4 current:   0.00 A
 Fan 5 current:   0.00 A  
 Fan 6 current:   0.00 A  
 Fan 7 current:   0.00 A  
-Fan 8 current:   9.00 mA 
+Fan 8 current:   9.00 mA
+
+[leo@manjaro]$ sensors
+quadro-hid-3-3
+Adapter: HID adapter
+Fan 1 voltage:     12.13 V  
+Fan 2 voltage:     12.13 V  
+Fan 3 voltage:     12.13 V  
+Fan 4 voltage:     12.13 V  
+Fan 1 speed:       643 RPM
+Fan 2 speed:      1756 RPM
+Fan 3 speed:       659 RPM
+Fan 4 speed:       650 RPM
+Flow speed [l/h]:   60 RPM
+Sensor 1:          +33.9°C  
+Sensor 2:          +25.3°C  
+Sensor 3:          +37.6°C  
+Sensor 4:          +33.3°C  
+Fan 1 power:      290.00 mW 
+Fan 2 power:        0.00 W  
+Fan 3 power:      260.00 mW 
+Fan 4 power:      260.00 mW 
+Fan 1 current:     24.00 mA 
+Fan 2 current:      0.00 A  
+Fan 3 current:     22.00 mA 
+Fan 4 current:     22.00 mA
 ```
 
 ## Repository contents

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -514,12 +514,29 @@ static int aqc_write(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 		switch (attr) {
 		case hwmon_pwm_enable:
 			if (priv->fan_ctrl_offsets != NULL) {
-				if (val < 0 || val > 7)
-					return -EINVAL;
-
+				switch (priv->kind) {
+				case d5next:
+					if (val < 0 || val > 3)
+						return -EINVAL;
+					break;
+				case quadro:
+				case octo:
+					if (val < 0 || val > priv->num_fans + 3)
+						return -EINVAL;
+					if (val == channel + 4)
+						return -EINVAL;
+					if (val > 3) {
+						ret = aqc_get_ctrl_val(priv, priv->fan_ctrl_offsets[val - 4], 8);
+						if (ret > 2)
+							return -EINVAL;
+					}
+					break;
+				default:
+					break;
+				}
 				if (val > 0)
 					ret = aqc_set_ctrl_val(priv, priv->fan_ctrl_offsets[channel],
-						       val - 1, 16); /* subtract 1 to convert pwm_enable from hwmon to aqc */
+						       val - 1, 8); /* subtract 1 to convert pwm_enable from hwmon to aqc */
 				if (ret < 0)
 					return ret;
 			}

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -64,6 +64,7 @@ static u8 secondary_ctrl_report[] = {
 #define AQC_FAN_CURRENT_OFFSET		0x04
 #define AQC_FAN_POWER_OFFSET		0x06
 #define AQC_FAN_SPEED_OFFSET		0x08
+#define AQC_FAN_PWM_OFFSET			0x01
 
 
 /* Register offsets for the D5 Next pump */
@@ -72,19 +73,19 @@ static u8 secondary_ctrl_report[] = {
 #define D5NEXT_FAN_OFFSET		0x5f
 #define D5NEXT_PUMP_OFFSET		0x6c
 static u8 d5next_sensor_fan_offsets[] = { D5NEXT_PUMP_OFFSET, D5NEXT_FAN_OFFSET};
-static u16 d5next_ctrl_fan_offsets[] = { 0x97, 0x42};
+static u16 d5next_ctrl_fan_offsets[] = { 0x96, 0x41};
 
 /* Register offsets for the Octo fan controller */
 static u8 octo_sensor_fan_offsets[] = { 0x7D, 0x8A, 0x97, 0xA4, 0xB1, 0xBE, 0xCB, 0xD8 };
 
 /* Fan speed registers in Octo control report (from 0-100%) */
-static u16 octo_ctrl_fan_offsets[] = { 0x5B, 0xB0, 0x105, 0x15A, 0x1AF, 0x204, 0x259, 0x2AE };
+static u16 octo_ctrl_fan_offsets[] = { 0x5A, 0xAF, 0x104, 0x159, 0x1AE, 0x203, 0x258, 0x2AD };
 
 /* Register offsets for the Quadro fan controller */
 static u8 quadro_sensor_fan_offsets[] = { 0x70, 0x7D, 0x8A, 0x97};
 
 /* Fan speed registers in Quadro control report (from 0-100%) */
-static u16 quadro_ctrl_fan_offsets[] = { 0x37, 0x8c, 0xe1, 0x136};
+static u16 quadro_ctrl_fan_offsets[] = { 0x36, 0x8b, 0xe0, 0x135};
 
 /* Labels for D5 Next */
 static const char *const label_d5next_temp[] = {
@@ -434,14 +435,14 @@ static int aqc_read(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 		if (priv->fan_ctrl_offsets != NULL) {
 			switch (attr) {
 			case hwmon_pwm_enable:
-				ret = aqc_get_u8_val(priv, priv->fan_ctrl_offsets[channel] - 1);
+				ret = aqc_get_u8_val(priv, priv->fan_ctrl_offsets[channel]);
 				if (ret < 0)
 					return ret;
 
 				*val = ret + 1;
 				break;
 			case hwmon_pwm_input:
-				ret = aqc_get_ctrl_val(priv, priv->fan_ctrl_offsets[channel]);
+				ret = aqc_get_ctrl_val(priv, priv->fan_ctrl_offsets[channel] + AQC_FAN_PWM_OFFSET);
 				if (ret < 0)
 					return ret;
 
@@ -508,7 +509,7 @@ static int aqc_write(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 					return -EINVAL;
 
 				if (val > 0)
-					ret = aqc_set_u8_val(priv, priv->fan_ctrl_offsets[channel] - 1,
+					ret = aqc_set_u8_val(priv, priv->fan_ctrl_offsets[channel],
 						       val - 1);
 				if (ret < 0)
 					return ret;
@@ -520,7 +521,7 @@ static int aqc_write(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 				if (pwm_value < 0)
 					return pwm_value;
 
-				ret = aqc_set_ctrl_val(priv, priv->fan_ctrl_offsets[channel],
+				ret = aqc_set_ctrl_val(priv, priv->fan_ctrl_offsets[channel] + AQC_FAN_PWM_OFFSET,
 						       pwm_value);
 				if (ret < 0)
 					return ret;

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -275,7 +275,7 @@ static int aqc_send_ctrl_data(struct aqc_data *priv)
 }
 
 /* Refreshes the control buffer and returns u16 value at offset */
-static int aqc_get_u16_val(struct aqc_data *priv, int offset)
+static int aqc_get_ctrl_val(struct aqc_data *priv, int offset)
 {
 	int ret;
 
@@ -310,7 +310,7 @@ unlock_and_return:
 	return ret;
 }
 
-static int aqc_set_u16_val(struct aqc_data *priv, int offset, long val)
+static int aqc_set_ctrl_val(struct aqc_data *priv, int offset, long val)
 {
 	int ret;
 
@@ -438,7 +438,7 @@ static int aqc_read(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 				*val = ret;
 				break;
 			case hwmon_pwm_input:
-				ret = aqc_get_u16_val(priv, priv->fan_ctrl_offsets[channel]);
+				ret = aqc_get_ctrl_val(priv, priv->fan_ctrl_offsets[channel]);
 				if (ret < 0)
 					return ret;
 
@@ -516,7 +516,7 @@ static int aqc_write(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 				if (pwm_value < 0)
 					return pwm_value;
 
-				ret = aqc_set_u16_val(priv, priv->fan_ctrl_offsets[channel],
+				ret = aqc_set_ctrl_val(priv, priv->fan_ctrl_offsets[channel],
 						       pwm_value);
 				if (ret < 0)
 					return ret;

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -501,8 +501,8 @@ static int aqc_write(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 		switch (attr) {
 		case hwmon_pwm_enable:
 			if (priv->fan_ctrl_offsets != NULL) {
-				if (val < 0)
-					return val;
+				if (val < 0 || val > 6)
+					return -EINVAL;
 
 				ret = aqc_set_u8_val(priv, priv->fan_ctrl_offsets[channel] - 1,
 						       val);

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -339,7 +339,6 @@ static int aqc_set_u8_val(struct aqc_data *priv, int offset, long val)
 	if (ret < 0)
 		goto unlock_and_return;
 
-	// put_unaligned_be16((u16)val, priv->buffer + offset);
 	priv->buffer[offset] = (u8) val;
 
 	ret = aqc_send_ctrl_data(priv);
@@ -437,7 +436,6 @@ static int aqc_read(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 					return ret;
 
 				*val = ret;
-				// *val = 3;
 				break;
 			case hwmon_pwm_input:
 				ret = aqc_get_u16_val(priv, priv->fan_ctrl_offsets[channel]);

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -438,7 +438,7 @@ static int aqc_read(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 				if (ret < 0)
 					return ret;
 
-				*val = ret;
+				*val = ret + 1;
 				break;
 			case hwmon_pwm_input:
 				ret = aqc_get_ctrl_val(priv, priv->fan_ctrl_offsets[channel]);
@@ -504,11 +504,12 @@ static int aqc_write(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 		switch (attr) {
 		case hwmon_pwm_enable:
 			if (priv->fan_ctrl_offsets != NULL) {
-				if (val < 0 || val > 6)
+				if (val < 0 || val > 7)
 					return -EINVAL;
 
+				if (val > 0)
 					ret = aqc_set_u8_val(priv, priv->fan_ctrl_offsets[channel] - 1,
-						       val);
+						       val - 1);
 				if (ret < 0)
 					return ret;
 			}

--- a/docs/aquacomputer_d5next.rst
+++ b/docs/aquacomputer_d5next.rst
@@ -9,6 +9,7 @@ Supported devices:
 * Aquacomputer Farbwerk RGB controller
 * Aquacomputer Farbwerk 360 RGB controller
 * Aquacomputer Octo fan controller
+* Aquacomputer Quadro fan
 
 Author: Aleksa Savic
 
@@ -25,12 +26,15 @@ optional and allows it to be controlled using temperature curves directly from t
 pump. If it's not connected, the fan-related sensors will report zeroes.
 
 The pump can be configured either through software or via its physical
-interface. Configuring the pump through this driver is not implemented, as it
+interface. Configuring the pump and the other devices through this driver is not implemented completly, as it
 seems to require sending it a complete configuration. That includes addressable
 RGB LEDs, for which there is no standard sysfs interface. Thus, that task is
 better suited for userspace tools.
 
 The Octo exposes four temperature sensors and eight PWM controllable fans, along
+with their speed (in RPM), power, voltage and current.
+
+The Quadro exposes four temperature sensors, a flow sensor and four PWM controllable fans, along
 with their speed (in RPM), power, voltage and current.
 
 The Farbwerk and Farbwerk 360 expose four temperature sensors. Depending on the device,
@@ -47,10 +51,12 @@ Sysfs entries
 
 ================ =============================================
 temp[1-4]_input  Temperature sensors (in millidegrees Celsius)
-fan[1-2]_input   Pump/fan speed (in RPM)
-power[1-2]_input Pump/fan power (in micro Watts)
-in[0-2]_input    Pump/fan voltage (in milli Volts)
-curr[1-2]_input  Pump/fan current (in milli Amperes)
+fan[1-8]_input   Pump/fan speed (in RPM) / Flow speed (in l/h)
+power[1-8]_input Pump/fan power (in micro Watts)
+in[1-8]_input    Pump/fan voltage (in milli Volts)
+curr[1-8]_input  Pump/fan current (in milli Amperes)
+pwm[1-8]         Fan PWM (0 - 255)
+pwm[1-8]_enable  Fan control mode
 ================ =============================================
 
 Debugfs entries

--- a/docs/aquacomputer_d5next.rst
+++ b/docs/aquacomputer_d5next.rst
@@ -40,8 +40,8 @@ along with their speed (in RPM), power, voltage and current.
 The possible values for pwm_enable are:
 0: no change
 1: manual pwm mode
-2: target temp mode
-3: temp curve mode
+2: PID control mode
+3: fan curve mode
 4: follow fan1 pwm
 5: follow fan2 pwm
 6: follow fan3 pwm

--- a/docs/aquacomputer_d5next.rst
+++ b/docs/aquacomputer_d5next.rst
@@ -9,7 +9,7 @@ Supported devices:
 * Aquacomputer Farbwerk RGB controller
 * Aquacomputer Farbwerk 360 RGB controller
 * Aquacomputer Octo fan controller
-* Aquacomputer Quadro fan
+* Aquacomputer Quadro fan controller
 
 Author: Aleksa Savic
 
@@ -27,7 +27,7 @@ pump. If it's not connected, the fan-related sensors will report zeroes.
 
 The pump can be configured either through software or via its physical
 interface. Configuring the pump and the other devices through this driver 
-is not implemented completly, as it seems to require sending it a complete 
+is not implemented completely, as it seems to require sending it a complete 
 configuration. That includes addressable RGB LEDs, for which there is no standard
 sysfs interface. Thus, that task is better suited for userspace tools.
 

--- a/docs/aquacomputer_d5next.rst
+++ b/docs/aquacomputer_d5next.rst
@@ -53,7 +53,7 @@ Sysfs entries
 temp[1-4]_input  Temperature sensors (in millidegrees Celsius)
 fan[1-8]_input   Pump/fan speed (in RPM) / Flow speed (in l/h)
 power[1-8]_input Pump/fan power (in micro Watts)
-in[1-8]_input    Pump/fan voltage (in milli Volts)
+in[0-7]_input    Pump/fan voltage (in milli Volts)
 curr[1-8]_input  Pump/fan current (in milli Amperes)
 pwm[1-8]         Fan PWM (0 - 255)
 pwm[1-8]_enable  Fan control mode

--- a/docs/aquacomputer_d5next.rst
+++ b/docs/aquacomputer_d5next.rst
@@ -38,14 +38,21 @@ The Quadro exposes four temperature sensors, a flow sensor and four PWM controll
 along with their speed (in RPM), power, voltage and current.
 
 The possible values for pwm_enable are:
+for D5 Next, Quadro and Octo
 0: no change
 1: manual pwm mode
 2: PID control mode
 3: fan curve mode
+additionally for Quadro and Octo
 4: follow fan1 pwm
 5: follow fan2 pwm
 6: follow fan3 pwm
 7: follow fan4 pwm
+additionally for Octo
+8: follow fan5 pwm
+9: follow fan6 pwm
+10: follow fan7 pwm
+11: follow fan8 pwm
 
 
 The Farbwerk and Farbwerk 360 expose four temperature sensors. Depending on the device,

--- a/docs/aquacomputer_d5next.rst
+++ b/docs/aquacomputer_d5next.rst
@@ -26,16 +26,16 @@ optional and allows it to be controlled using temperature curves directly from t
 pump. If it's not connected, the fan-related sensors will report zeroes.
 
 The pump can be configured either through software or via its physical
-interface. Configuring the pump and the other devices through this driver is not implemented completly, as it
-seems to require sending it a complete configuration. That includes addressable
-RGB LEDs, for which there is no standard sysfs interface. Thus, that task is
-better suited for userspace tools.
+interface. Configuring the pump and the other devices through this driver 
+is not implemented completly, as it seems to require sending it a complete 
+configuration. That includes addressable RGB LEDs, for which there is no standard
+sysfs interface. Thus, that task is better suited for userspace tools.
 
 The Octo exposes four temperature sensors and eight PWM controllable fans, along
 with their speed (in RPM), power, voltage and current.
 
-The Quadro exposes four temperature sensors, a flow sensor and four PWM controllable fans, along
-with their speed (in RPM), power, voltage and current.
+The Quadro exposes four temperature sensors, a flow sensor and four PWM controllable fans,
+along with their speed (in RPM), power, voltage and current.
 
 The possible values for pwm_enable are:
 0: no change

--- a/docs/aquacomputer_d5next.rst
+++ b/docs/aquacomputer_d5next.rst
@@ -37,6 +37,17 @@ with their speed (in RPM), power, voltage and current.
 The Quadro exposes four temperature sensors, a flow sensor and four PWM controllable fans, along
 with their speed (in RPM), power, voltage and current.
 
+The possible values for pwm_enable are:
+0: no change
+1: manual pwm mode
+2: target temp mode
+3: temp curve mode
+4: follow fan1 pwm
+5: follow fan2 pwm
+6: follow fan3 pwm
+7: follow fan4 pwm
+
+
 The Farbwerk and Farbwerk 360 expose four temperature sensors. Depending on the device,
 not all sysfs and debugfs entries will be available.
 


### PR DESCRIPTION
Adds the sysfs entry pwm_enable. This entry allows to change the fan control mode.
The supported values are:
- 0: manual pwm mode
- 1: target temp mode
- 2: temp curve mode
- 3: follow fan1 pwm
- 4: follow fan2 pwm
- 5: follow fan3 pwm
- 6: follow fan4 pwm

I have only tested this on the quadro, but it should also work with d5 next and octo. Can someone test this?