### PR TITLE
add sysfs entry pwm_auto_channels_temp

### DIFF
--- a/.github/workflows/compile-driver.yaml
+++ b/.github/workflows/compile-driver.yaml
@@ -12,5 +12,20 @@
       steps:
       - name: checkout repo
         uses: actions/checkout@v2
+      - name: checkout linux
+        uses: actions/checkout@v2
+        with:
+          repository: torvalds/linux
+          path: ./linux
+          ref:  v5.18
+      - name: install libelf-dev
+        run: |
+          sudo apt update
+          sudo apt install libelf-dev
+      - name: prepare linux
+        working-directory: ./linux
+        run: |
+          make x86_64_defconfig
+          make modules_prepare
       - name: compile driver
-        run: make
+        run: make -C ./linux M=$PWD modules

--- a/docs/aquacomputer_d5next.rst
+++ b/docs/aquacomputer_d5next.rst
@@ -77,15 +77,16 @@ the kernel and supports hotswapping.
 Sysfs entries
 -------------
 
-================ =============================================
-temp[1-4]_input  Temperature sensors (in millidegrees Celsius)
-fan[1-8]_input   Pump/fan speed (in RPM) / Flow speed (in l/h)
-power[1-8]_input Pump/fan power (in micro Watts)
-in[0-7]_input    Pump/fan voltage (in milli Volts)
-curr[1-8]_input  Pump/fan current (in milli Amperes)
-pwm[1-8]         Fan PWM (0 - 255)
-pwm[1-8]_enable  Fan control mode
-================ =============================================
+=========================== =============================================
+temp[1-4]_input             Temperature sensors (in millidegrees Celsius)
+fan[1-8]_input              Pump/fan speed (in RPM) / Flow speed (in l/h)
+power[1-8]_input            Pump/fan power (in micro Watts)
+in[0-7]_input               Pump/fan voltage (in milli Volts)
+curr[1-8]_input             Pump/fan current (in milli Amperes)
+pwm[1-8]                    Fan PWM (0 - 255)
+pwm[1-8]_enable             Fan control mode
+pwm[1-8]_auto_channels_temp Fan control temperature sensors select
+=========================== =============================================
 
 Debugfs entries
 ---------------


### PR DESCRIPTION
Adds the sysfs entry pwm_auto_channels_temp which allows to select the temperature sensor for the automatic control modes (PID control mode + fan curve mode).
Also improves the build action to allow newer kernel versions.
reopen of #19