### PR TITLE
Add sysfs entry temp_offset

### DIFF
--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -79,6 +79,7 @@ static u8 secondary_ctrl_report[] = {
 #define D5NEXT_5V_VOLTAGE		0x39
 #define D5NEXT_12V_VOLTAGE		0x37
 #define D5NEXT_CTRL_REPORT_SIZE		0x329
+#define D5NEXT_TEMP_CTRL_OFFSET		0x16
 static u8 d5next_sensor_fan_offsets[] = { D5NEXT_PUMP_OFFSET, D5NEXT_FAN_OFFSET };
 
 /* Pump and fan speed registers in D5 Next control report (from 0-100%) */
@@ -89,8 +90,10 @@ static u16 d5next_ctrl_fan_offsets[] = { 0x96, 0x41 };
 #define FARBWERK_SENSOR_START		0x2f
 
 /* Register offsets for the Farbwerk 360 RGB controller */
-#define FARBWERK360_NUM_SENSORS		4
-#define FARBWERK360_SENSOR_START	0x32
+#define FARBWERK360_NUM_SENSORS			4
+#define FARBWERK360_SENSOR_START		0x32
+#define FARBWERK360_CTRL_REPORT_SIZE	0x68A
+#define FARBWERK360_TEMP_CTRL_OFFSET	0x8
 
 /* Register offsets for the Octo fan controller */
 #define OCTO_POWER_CYCLES		0x18
@@ -98,6 +101,7 @@ static u16 d5next_ctrl_fan_offsets[] = { 0x96, 0x41 };
 #define OCTO_NUM_SENSORS		4
 #define OCTO_SENSOR_START		0x3D
 #define OCTO_CTRL_REPORT_SIZE		0x65F
+#define OCTO_TEMP_CTRL_OFFSET		0xa
 static u8 octo_sensor_fan_offsets[] = { 0x7D, 0x8A, 0x97, 0xA4, 0xB1, 0xBE, 0xCB, 0xD8 };
 
 /* Fan speed registers in Octo control report (from 0-100%) */
@@ -876,7 +880,7 @@ static int aqc_probe(struct hid_device *hdev, const struct hid_device_id *id)
 		priv->temp_sensor_start_offset = D5NEXT_COOLANT_TEMP;
 		priv->power_cycle_count_offset = D5NEXT_POWER_CYCLES;
 		priv->buffer_size = D5NEXT_CTRL_REPORT_SIZE;
-		priv->temp_ctrl_offset = 0;
+		priv->temp_ctrl_offset = D5NEXT_TEMP_CTRL_OFFSET;
 
 		priv->temp_label = label_d5next_temp;
 		priv->speed_label = label_d5next_speeds;
@@ -900,7 +904,8 @@ static int aqc_probe(struct hid_device *hdev, const struct hid_device_id *id)
 		priv->num_fans = 0;
 		priv->num_temp_sensors = FARBWERK360_NUM_SENSORS;
 		priv->temp_sensor_start_offset = FARBWERK360_SENSOR_START;
-		priv->temp_ctrl_offset = 0;
+		priv->buffer_size = FARBWERK360_CTRL_REPORT_SIZE;
+		priv->temp_ctrl_offset = FARBWERK360_TEMP_CTRL_OFFSET;
 
 		priv->temp_label = label_temp_sensors;
 		break;
@@ -914,7 +919,7 @@ static int aqc_probe(struct hid_device *hdev, const struct hid_device_id *id)
 		priv->temp_sensor_start_offset = OCTO_SENSOR_START;
 		priv->power_cycle_count_offset = OCTO_POWER_CYCLES;
 		priv->buffer_size = OCTO_CTRL_REPORT_SIZE;
-		priv->temp_ctrl_offset = 0;
+		priv->temp_ctrl_offset = OCTO_TEMP_CTRL_OFFSET;
 
 		priv->temp_label = label_temp_sensors;
 		priv->speed_label = label_fan_speed;

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -724,7 +724,8 @@ static const struct hwmon_chip_info aqc_chip_info = {
 
 static int aqc_raw_event(struct hid_device *hdev, struct hid_report *report, u8 *data, int size)
 {
-	int i, sensor_value;
+	int i;
+	s16 sensor_value;
 	struct aqc_data *priv;
 
 	if (report->id != STATUS_REPORT_ID)

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -308,7 +308,7 @@ static int aqc_send_ctrl_data(struct aqc_data *priv)
 }
 
 /* Refreshes the control buffer and stores value at offset in val */
-static int aqc_get_ctrl_val(struct aqc_data *priv, int offset, long* val, size_t size)
+static int aqc_get_ctrl_val(struct aqc_data *priv, int offset, long *val, size_t size)
 {
 	int ret;
 

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -79,7 +79,7 @@ static u8 secondary_ctrl_report[] = {
 #define D5NEXT_5V_VOLTAGE		0x39
 #define D5NEXT_12V_VOLTAGE		0x37
 #define D5NEXT_CTRL_REPORT_SIZE		0x329
-#define D5NEXT_TEMP_CTRL_OFFSET		0x16
+#define D5NEXT_TEMP_CTRL_OFFSET		0x2D
 static u8 d5next_sensor_fan_offsets[] = { D5NEXT_PUMP_OFFSET, D5NEXT_FAN_OFFSET };
 
 /* Pump and fan speed registers in D5 Next control report (from 0-100%) */
@@ -92,7 +92,7 @@ static u16 d5next_ctrl_fan_offsets[] = { 0x96, 0x41 };
 /* Register offsets for the Farbwerk 360 RGB controller */
 #define FARBWERK360_NUM_SENSORS			4
 #define FARBWERK360_SENSOR_START		0x32
-#define FARBWERK360_CTRL_REPORT_SIZE	0x68A
+#define FARBWERK360_CTRL_REPORT_SIZE	0x682
 #define FARBWERK360_TEMP_CTRL_OFFSET	0x8
 
 /* Register offsets for the Octo fan controller */

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -550,8 +550,9 @@ static int aqc_write(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 	case hwmon_temp:
 		switch (attr) {
 		case hwmon_temp_offset:
+			val = clamp_val(val, -15000, 15000) / 10;
 			ret = aqc_set_ctrl_val(priv, priv->temp_ctrl_offset + channel * AQC_TEMP_SENSOR_SIZE,
-								val/10, 16);
+								val, 16);
 			if (ret < 0)
 				return ret;
 			break;

--- a/docs/aquacomputer_d5next.rst
+++ b/docs/aquacomputer_d5next.rst
@@ -77,8 +77,9 @@ the kernel and supports hotswapping.
 Sysfs entries
 -------------
 
-=========================== =============================================
+=========================== ==============================================================
 temp[1-4]_input             Temperature sensors (in millidegrees Celsius)
+temp[1-4]_offset            Temperature sensor correction offset (in millidegrees Celsius)
 fan[1-8]_input              Pump/fan speed (in RPM) / Flow speed (in dL/h)
 power[1-8]_input            Pump/fan power (in micro Watts)
 in[0-7]_input               Pump/fan voltage (in milli Volts)
@@ -86,7 +87,7 @@ curr[1-8]_input             Pump/fan current (in milli Amperes)
 pwm[1-8]                    Fan PWM (0 - 255)
 pwm[1-8]_enable             Fan control mode
 pwm[1-8]_auto_channels_temp Fan control temperature sensors select
-=========================== =============================================
+=========================== ===============================================================
 
 Debugfs entries
 ---------------


### PR DESCRIPTION
Adds the sysfs entry temp_offset, which allows to set a correction offset for each temperature sensor.

- [ ]  Find and add control offsets for the other devices