### PR TITLE
makefile: declare targets PHONY, support bare 'install', 'all'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
- KDIR ?= /lib/modules/`uname -r`/build
+.PHONY: all modules install modules_install clean
+
+# external KDIR specification is supported
+KDIR ?= /lib/modules/$(shell uname -r)/build
+
+all: modules
+
+install: modules_install
 
 modules modules_install clean:
 	make -C $(KDIR) M=$$PWD $@


### PR DESCRIPTION
* Since every Linux machine is using GNU Make, use the `PHONY` target here as best practice.
* Support `all` target as default, mapped to `modules`. This way we never run `install` by default (which probably requires permissions).
* Support `install` as an alias for `modules_install`

(hey there! i'm sosodank on r/watercooling =])