### PR TITLE
Add pwm control for Aquaero

### DIFF
--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -12,6 +12,7 @@
 
 #include <linux/crc16.h>
 #include <linux/debugfs.h>
+#include <linux/delay.h>
 #include <linux/hid.h>
 #include <linux/hwmon.h>
 #include <linux/jiffies.h>
@@ -19,7 +20,6 @@
 #include <linux/mutex.h>
 #include <linux/seq_file.h>
 #include <asm/unaligned.h>
-#include <linux/delay.h>
 
 #define USB_VENDOR_ID_AQUACOMPUTER	0x0c70
 #define USB_PRODUCT_ID_AQUAERO	 	0xf001
@@ -109,7 +109,8 @@ static u16 aquaero_ctrl_fan_offsets[] = { 0x20c, 0x220, 0x234, 0x248 };
 #define AQUAERO_FAN_CTRL_SRC_OFFSET	0x10
 
 #define AQUAERO_CTRL_PRESET_ID		0x5c
-#define AQUAERO_CTRL_PRESET_OFFSET	0x55c
+#define AQUAERO_CTRL_PRESET_SIZE	0x02
+#define AQUAERO_CTRL_PRESET_START	0x55c
 
 /* Register offsets for the D5 Next pump */
 #define D5NEXT_POWER_CYCLES		0x18
@@ -671,7 +672,7 @@ static int aqc_read(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 			if (priv->kind == aquaero) {
 				ret =
 					aqc_get_ctrl_val(priv,
-					    AQUAERO_CTRL_PRESET_OFFSET + channel * 2, val, 16);
+					    AQUAERO_CTRL_PRESET_START + channel * AQUAERO_CTRL_PRESET_SIZE, val, 16);
 				if (ret < 0)
 					return ret;
 			} else {
@@ -816,7 +817,7 @@ static int aqc_write(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 				/* Write pwm value to preset corresponding to the channel */
 				ret =
 					aqc_set_ctrl_val(priv,
-							AQUAERO_CTRL_PRESET_OFFSET + channel * 2, pwm_value, 16);
+							AQUAERO_CTRL_PRESET_START + channel * AQUAERO_CTRL_PRESET_SIZE, pwm_value, 16);
 				if (ret < 0)
 					return ret;
 

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -105,6 +105,8 @@ static u16 aquaero_ctrl_fan_offsets[] = { 0x20c, 0x220, 0x234, 0x248 };
 #define AQUAERO_FAN_POWER_OFFSET	0x08
 #define AQUAERO_FAN_SPEED_OFFSET	0x00
 
+#define AQUAERO_FAN_CTRL_MIN_RPM_OFFSET	0x00
+#define AQUAERO_FAN_CTRL_MAX_RPM_OFFSET	0x02
 #define AQUAERO_FAN_CTRL_MIN_PWR_OFFSET	0x04
 #define AQUAERO_FAN_CTRL_MODE_OFFSET	0x0f
 #define AQUAERO_FAN_CTRL_SRC_OFFSET	0x10
@@ -566,22 +568,34 @@ static umode_t aqc_is_visible(const void *data, enum hwmon_sensor_types type, u3
 		}
 		break;
 	case hwmon_fan:
-		switch (priv->kind) {
-		case highflownext:
-			/* Special case to support flow sensor, water quality and conductivity */
-			if (channel < 3)
-				return 0444;
-			break;
-		case quadro:
-			/* Special case to support flow sensor */
-			if (channel < priv->num_fans + 1)
-				return 0444;
-			break;
-		default:
-			if (channel < priv->num_fans)
-				return 0444;
-			break;
-		}
+		switch (attr) {
+			case hwmon_fan_input:
+			case hwmon_fan_label:
+				switch (priv->kind) {
+				case highflownext:
+					/* Special case to support flow sensor, water quality and conductivity */
+					if (channel < 3)
+						return 0444;
+					break;
+				case quadro:
+					/* Special case to support flow sensor */
+					if (channel < priv->num_fans + 1)
+						return 0444;
+					break;
+				default:
+					if (channel < priv->num_fans)
+						return 0444;
+					break;
+				}
+				break;
+			case hwmon_fan_min:
+			case hwmon_fan_max:
+				if (priv->kind == aquaero && channel < priv->num_fans)
+					return 0644;
+			default:
+				break;
+			}
+		
 		break;
 	case hwmon_power:
 		switch (priv->kind) {
@@ -656,7 +670,27 @@ static int aqc_read(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 		}
 		break;
 	case hwmon_fan:
-		*val = priv->speed_input[channel];
+		switch (attr) {
+		case hwmon_fan_input:
+			*val = priv->speed_input[channel];
+			break;
+		case hwmon_fan_min:
+			ret =
+				aqc_get_ctrl_val(priv,
+					priv->fan_ctrl_offsets[channel] + AQUAERO_FAN_CTRL_MIN_RPM_OFFSET, val, 16);
+			if (ret < 0)
+				return ret;
+			break;
+		case hwmon_fan_max:
+			ret =
+				aqc_get_ctrl_val(priv,
+					priv->fan_ctrl_offsets[channel] + AQUAERO_FAN_CTRL_MAX_RPM_OFFSET, val, 16);
+			if (ret < 0)
+				return ret;
+			break;
+		default:
+			return -EOPNOTSUPP;
+		}
 		break;
 	case hwmon_power:
 		*val = priv->power_input[channel];
@@ -713,8 +747,9 @@ static int aqc_read(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 			default:
 				break;
 			}
-		default:
 			break;
+		default:
+			return -EOPNOTSUPP;
 		}
 		break;
 	case hwmon_in:
@@ -778,6 +813,26 @@ static int aqc_write(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 			    aqc_set_ctrl_val(priv,
 					     priv->temp_ctrl_offset +
 					     channel * AQC_TEMP_SENSOR_SIZE, val, 16);
+			if (ret < 0)
+				return ret;
+			break;
+		default:
+			return -EOPNOTSUPP;
+		}
+		break;
+	case hwmon_fan:
+		switch (attr) {
+		case hwmon_fan_min:
+			val = clamp_val(val, 0, 15000);
+			ret = aqc_set_ctrl_val(priv, 
+				priv->fan_ctrl_offsets[channel] + AQUAERO_FAN_CTRL_MIN_RPM_OFFSET, val, 16);
+			if (ret < 0)
+				return ret;
+			break;
+		case hwmon_fan_max:
+			val = clamp_val(val, 0, 15000);
+			ret = aqc_set_ctrl_val(priv, 
+				priv->fan_ctrl_offsets[channel] + AQUAERO_FAN_CTRL_MAX_RPM_OFFSET, val, 16);
 			if (ret < 0)
 				return ret;
 			break;
@@ -952,10 +1007,10 @@ static const struct hwmon_channel_info *aqc_info[] = {
 			   HWMON_T_INPUT | HWMON_T_LABEL,
 			   HWMON_T_INPUT | HWMON_T_LABEL),
 	HWMON_CHANNEL_INFO(fan,
-			   HWMON_F_INPUT | HWMON_F_LABEL,
-			   HWMON_F_INPUT | HWMON_F_LABEL,
-			   HWMON_F_INPUT | HWMON_F_LABEL,
-			   HWMON_F_INPUT | HWMON_F_LABEL,
+			   HWMON_F_INPUT | HWMON_F_LABEL | HWMON_F_MIN | HWMON_F_MAX,
+			   HWMON_F_INPUT | HWMON_F_LABEL | HWMON_F_MIN | HWMON_F_MAX,
+			   HWMON_F_INPUT | HWMON_F_LABEL | HWMON_F_MIN | HWMON_F_MAX,
+			   HWMON_F_INPUT | HWMON_F_LABEL | HWMON_F_MIN | HWMON_F_MAX,
 			   HWMON_F_INPUT | HWMON_F_LABEL,
 			   HWMON_F_INPUT | HWMON_F_LABEL,
 			   HWMON_F_INPUT | HWMON_F_LABEL,

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -569,33 +569,32 @@ static umode_t aqc_is_visible(const void *data, enum hwmon_sensor_types type, u3
 		break;
 	case hwmon_fan:
 		switch (attr) {
-			case hwmon_fan_input:
-			case hwmon_fan_label:
-				switch (priv->kind) {
-				case highflownext:
-					/* Special case to support flow sensor, water quality and conductivity */
-					if (channel < 3)
-						return 0444;
-					break;
-				case quadro:
-					/* Special case to support flow sensor */
-					if (channel < priv->num_fans + 1)
-						return 0444;
-					break;
-				default:
-					if (channel < priv->num_fans)
-						return 0444;
-					break;
-				}
+		case hwmon_fan_input:
+		case hwmon_fan_label:
+			switch (priv->kind) {
+			case highflownext:
+				/* Special case to support flow sensor, water quality and conductivity */
+				if (channel < 3)
+					return 0444;
 				break;
-			case hwmon_fan_min:
-			case hwmon_fan_max:
-				if (priv->kind == aquaero && channel < priv->num_fans)
-					return 0644;
+			case quadro:
+				/* Special case to support flow sensor */
+				if (channel < priv->num_fans + 1)
+					return 0444;
+				break;
 			default:
+				if (channel < priv->num_fans)
+					return 0444;
 				break;
 			}
-		
+			break;
+		case hwmon_fan_min:
+		case hwmon_fan_max:
+			if (priv->kind == aquaero && channel < priv->num_fans)
+				return 0644;
+		default:
+			break;
+		}
 		break;
 	case hwmon_power:
 		switch (priv->kind) {
@@ -744,6 +743,7 @@ static int aqc_read(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 				break;
 			case 2: /* PWM mode */
 				*val = 1;
+				break;
 			default:
 				break;
 			}
@@ -824,14 +824,14 @@ static int aqc_write(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 		switch (attr) {
 		case hwmon_fan_min:
 			val = clamp_val(val, 0, 15000);
-			ret = aqc_set_ctrl_val(priv, 
+			ret = aqc_set_ctrl_val(priv,
 				priv->fan_ctrl_offsets[channel] + AQUAERO_FAN_CTRL_MIN_RPM_OFFSET, val, 16);
 			if (ret < 0)
 				return ret;
 			break;
 		case hwmon_fan_max:
 			val = clamp_val(val, 0, 15000);
-			ret = aqc_set_ctrl_val(priv, 
+			ret = aqc_set_ctrl_val(priv,
 				priv->fan_ctrl_offsets[channel] + AQUAERO_FAN_CTRL_MAX_RPM_OFFSET, val, 16);
 			if (ret < 0)
 				return ret;

--- a/re-docs/aquaero/aquaero5_control.hexpat
+++ b/re-docs/aquaero/aquaero5_control.hexpat
@@ -13,7 +13,7 @@ pwm
 struct Fan {
 be u16 min_rpm;
 be u16 max_rpm;
-be u16 min_percent;
+be u16 min_power;
 be u16 max_power;
 be u16 start_boost_power;
 be u16 start_boost_duration;


### PR DESCRIPTION
Added option to control the fans with static pwm. The control works in two steps: First the pwm value is written to preset controller. For simplicity I use the first controller for the first fan and so on. Second the ID of the preset controller is used as the fan control source.