### PR TITLE
Basic Leakshield integration

### DIFF
--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -193,6 +193,8 @@ static u16 quadro_ctrl_fan_offsets[] = { 0x36, 0x8b, 0xe0, 0x135 };
 #define LEAKSHIELD_PRESSURE_MAX 295
 #define LEAKSHIELD_PUMP_RPM_IN 101
 #define LEAKSHIELD_FLOW_IN 111
+#define LEAKSHIELD_RESERVOIR_VOLUME 313
+#define LEAKSHIELD_RESERVOIR_FILLED 311
 
 /* Labels for D5 Next */
 static const char *const label_d5next_temp[] = {
@@ -339,6 +341,8 @@ static const char *const label_leakshield_fan_speed[] = {
 	"Max Pressure [µbar]",
 	"User-Provided Pump Speed",
 	"User-Provided Flow [dL/h]",
+	"Reservoir Volume [ml]",
+	"Reservoir Filled [ml]",
 };
 
 struct aqc_fan_structure_offsets {
@@ -603,7 +607,7 @@ static umode_t aqc_is_visible(const void *data, enum hwmon_sensor_types type, u3
 				break;
 			case leakshield:
 				/* Special case for leakshield pressure sensor */
-				if (channel < 6)
+				if (channel < 8)
 					return 0444;
 				break;
 			case quadro:
@@ -1189,6 +1193,9 @@ static int aqc_raw_event(struct hid_device *hdev, struct hid_report *report, u8 
 		if (priv->speed_input[5] == AQC_TEMP_SENSOR_DISCONNECTED) {
 			priv->speed_input[5] = -ENODATA;
 		}
+
+		priv->speed_input[6] = get_unaligned_be16(data + LEAKSHIELD_RESERVOIR_VOLUME);
+		priv->speed_input[7] = get_unaligned_be16(data + LEAKSHIELD_RESERVOIR_FILLED);
 
 		/* code above expects temperature values to be laid out sequentially, but they're not */
 		priv->temp_input[1] = get_unaligned_be16(data + LEAKSHIELD_TEMPERATURE_2) * 10;

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -196,6 +196,16 @@ static u16 quadro_ctrl_fan_offsets[] = { 0x36, 0x8b, 0xe0, 0x135 };
 #define LEAKSHIELD_FLOW_IN 111
 #define LEAKSHIELD_RESERVOIR_VOLUME 313
 #define LEAKSHIELD_RESERVOIR_FILLED 311
+/* USB bulk message to report pump RPM and flow rate for pressure calculations */
+static u8 leakshield_usb_report_template[] = {
+	0x4, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+};
+#define LEAKSHIELD_USB_REPORT_LENGTH 49
+#define LEAKSHIELD_USB_REPORT_ENDPOINT 2
+#define LEAKSHIELD_USB_REPORT_PUMP_RPM_OFFSET 1
+#define LEAKSHIELD_USB_REPORT_FLOW_OFFSET 3
+
+
 
 /* Labels for D5 Next */
 static const char *const label_d5next_temp[] = {
@@ -607,7 +617,7 @@ static umode_t aqc_is_visible(const void *data, enum hwmon_sensor_types type, u3
 					return 0444;
 				break;
 			case leakshield:
-				/* Special case for leakshield sensors */
+				/* Special case for user-provided leakshield sensors */
 				if (channel == 1 || channel == 2)
 					return 0644;
 				if (channel < 5)
@@ -630,6 +640,7 @@ static umode_t aqc_is_visible(const void *data, enum hwmon_sensor_types type, u3
 				return 0644;
 			fallthrough;
 		case hwmon_fan_target:
+			/* Special case for leakshield pressure sensor */
 			if (priv->kind == leakshield && channel == 0)
 				return 0444;
 		default:
@@ -853,9 +864,6 @@ static int aqc_read_string(struct device *dev, enum hwmon_sensor_types type, u32
 	return 0;
 }
 
-static u8 leakshield_report_template[] = {
-	0x4, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x7f, 0xff, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-};
 
 
 static int aqc_leakshield_send_report(struct aqc_data *priv, int channel, long val)
@@ -872,40 +880,41 @@ static int aqc_leakshield_send_report(struct aqc_data *priv, int channel, long v
 		return -EINVAL;
 	}
 
-	/* map -1 to N/A and forbid out-of-bounds values */
-	if (val == -1)
-	    /* note: the device will still remember the old value for 5 minutes */
-		val16 = 0x7fff;
-	else if (val < 0 || val >= 0x7fff)
+	/* forbid out-of-bounds values */
+	if (val < -1 || val >= 0x7fff)
 		return -EINVAL;
+
+	if (val == -1)
+	    /* map -1 to N/A value. note: the device will still remember the old value for 5 minutes */
+		val16 = 0x7fff;
 	else
 		val16 = (u16)val;
 
-	/* leakshield_report_template is loaded into priv->buffer during initialization.
+	/* leakshield_usb_report_template is loaded into priv->buffer during initialization.
 	   if userland provides e.g. pump RPM and then flow rate, we don't want the flow
 	   rate update to clear the pump RPM, so we just keep the values saved in the buffer */
 
 	switch (channel) {
 	case 1:
-		put_unaligned_be16(val16, priv->buffer + 1);
+		put_unaligned_be16(val16, priv->buffer + LEAKSHIELD_USB_REPORT_PUMP_RPM_OFFSET);
 		break;
 	case 2:
-		put_unaligned_be16(val16, priv->buffer + 3);
+		put_unaligned_be16(val16, priv->buffer + LEAKSHIELD_USB_REPORT_FLOW_OFFSET);
 		break;
 	default:
 		return -EINVAL;
 	}
 
 	/* Init and xorout value for CRC-16/USB is 0xffff */
-	checksum = crc16(0xffff, priv->buffer, sizeof(leakshield_report_template));
+	checksum = crc16(0xffff, priv->buffer, LEAKSHIELD_USB_REPORT_LENGTH);
 	checksum ^= 0xffff;
 
 	/* Place the new checksum at the end of the report */
-	put_unaligned_be16(checksum, priv->buffer + sizeof(leakshield_report_template));
+	put_unaligned_be16(checksum, priv->buffer + LEAKSHIELD_USB_REPORT_LENGTH);
 
 	intf = to_usb_interface(priv->hdev->dev.parent);
 	usb_dev = interface_to_usbdev(intf);
-	pipe = usb_sndbulkpipe(usb_dev, 2);
+	pipe = usb_sndbulkpipe(usb_dev, LEAKSHIELD_USB_REPORT_ENDPOINT);
 	ret = usb_bulk_msg(usb_dev, pipe, priv->buffer, priv->buffer_size, &actual_length, 1000);
 
 	if (actual_length != priv->buffer_size) {
@@ -1542,7 +1551,7 @@ static int aqc_probe(struct hid_device *hdev, const struct hid_device_id *id)
 		priv->speed_label = label_leakshield_fan_speed;
 
 		/* plus two bytes checksum */
-		priv->buffer_size = sizeof(leakshield_report_template) + 2;
+		priv->buffer_size = LEAKSHIELD_USB_REPORT_LENGTH + 2;
 		break;
 	default:
 		break;
@@ -1585,7 +1594,7 @@ static int aqc_probe(struct hid_device *hdev, const struct hid_device_id *id)
 	}
 
 	if (priv->kind == leakshield) {
-		memcpy(priv->buffer, leakshield_report_template, sizeof(leakshield_report_template));
+		memcpy(priv->buffer, leakshield_usb_report_template, LEAKSHIELD_USB_REPORT_LENGTH);
 	}
 
 	mutex_init(&priv->mutex);

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -866,10 +866,20 @@ static int aqc_leakshield_send_report(struct aqc_data *priv, int channel, long v
 	int actual_length;
 	int ret;
 	u16 checksum;
+	u16 val16;
 
 	if (priv->kind != leakshield) {
 		return -EINVAL;
 	}
+
+	/* map -1 to N/A and forbid out-of-bounds values */
+	if (val == -1)
+	    /* note: the device will still remember the old value for 5 minutes */
+		val16 = 0x7fff;
+	else if (val < 0 || val >= 0x7fff)
+		return -EINVAL;
+	else
+		val16 = (u16)val;
 
 	/* leakshield_report_template is loaded into priv->buffer during initialization.
 	   if userland provides e.g. pump RPM and then flow rate, we don't want the flow
@@ -877,10 +887,10 @@ static int aqc_leakshield_send_report(struct aqc_data *priv, int channel, long v
 
 	switch (channel) {
 	case 1:
-		put_unaligned_be16(val, priv->buffer + 1);
+		put_unaligned_be16(val16, priv->buffer + 1);
 		break;
 	case 2:
-		put_unaligned_be16(val, priv->buffer + 3);
+		put_unaligned_be16(val16, priv->buffer + 3);
 		break;
 	default:
 		return -EINVAL;

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -74,7 +74,7 @@ static u8 aquaero_secondary_ctrl_report[] = {
 
 /* Register offsets for all Aquacomputer devices */
 #define AQC_TEMP_SENSOR_SIZE		0x02
-#define AQC_TEMP_SENSOR_DISCONNECTED	0x7FFF
+#define AQC_SENSOR_NA	0x7FFF
 #define AQC_POWER_CYCLES		0x18
 
 /* Register offsets for most Aquacomputer devices */
@@ -881,12 +881,12 @@ static int aqc_leakshield_send_report(struct aqc_data *priv, int channel, long v
 	}
 
 	/* forbid out-of-bounds values */
-	if (val < -1 || val >= 0x7fff)
+	if (val < -1 || val >= AQC_SENSOR_NA)
 		return -EINVAL;
 
 	if (val == -1)
 	    /* map -1 to N/A value. note: the device will still remember the old value for 5 minutes */
-		val16 = 0x7fff;
+		val16 = AQC_SENSOR_NA;
 	else
 		val16 = (u16)val;
 
@@ -1209,7 +1209,7 @@ static int aqc_raw_event(struct hid_device *hdev, struct hid_report *report, u8 
 		sensor_value = get_unaligned_be16(data +
 						  priv->temp_sensor_start_offset +
 						  i * AQC_TEMP_SENSOR_SIZE);
-		if (sensor_value == AQC_TEMP_SENSOR_DISCONNECTED)
+		if (sensor_value == AQC_SENSOR_NA)
 			priv->temp_input[i] = -ENODATA;
 		else
 			priv->temp_input[i] = sensor_value * 10;
@@ -1220,7 +1220,7 @@ static int aqc_raw_event(struct hid_device *hdev, struct hid_report *report, u8 
 		sensor_value = get_unaligned_be16(data +
 						  priv->virtual_temp_sensor_start_offset +
 						  j * AQC_TEMP_SENSOR_SIZE);
-		if (sensor_value == AQC_TEMP_SENSOR_DISCONNECTED)
+		if (sensor_value == AQC_SENSOR_NA)
 			priv->temp_input[i] = -ENODATA;
 		else
 			priv->temp_input[i] = sensor_value * 10;
@@ -1278,11 +1278,11 @@ static int aqc_raw_event(struct hid_device *hdev, struct hid_report *report, u8 
 		priv->speed_input_max[0] = get_unaligned_be16(data + LEAKSHIELD_PRESSURE_MAX) * 100;
 
 		priv->speed_input[1] = get_unaligned_be16(data + LEAKSHIELD_PUMP_RPM_IN);
-		if (priv->speed_input[1] == AQC_TEMP_SENSOR_DISCONNECTED) {
+		if (priv->speed_input[1] == AQC_SENSOR_NA) {
 			priv->speed_input[1] = -ENODATA;
 		}
 		priv->speed_input[2] = get_unaligned_be16(data + LEAKSHIELD_FLOW_IN);
-		if (priv->speed_input[2] == AQC_TEMP_SENSOR_DISCONNECTED) {
+		if (priv->speed_input[2] == AQC_SENSOR_NA) {
 			priv->speed_input[2] = -ENODATA;
 		}
 


### PR DESCRIPTION
Based on the discussion in #37 and the reverse-engineering work by @looncraz, here is a very basic integration with Leakshield. Right now it only reads the pressure value. I tried to keep the implementation very similar to `highflownext`, so the mbar pressure value is reported as fan RPM right now. The value is also divided by 10 because the device reports 10x mbar. This information loss is unfortunate of course, but I personally feel that since the decimal digit fluctuates a lot anyway, the usability benefit of dropping it outweighs the very minor loss of accuracy here. I wish there was a better way to report this though. Perhaps (ab)using the voltage or temperature sensor types would be a better fit here since they offer a decimal point?