### PR TITLE
Poweradjust3 sensor support, refactor legacy device reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The following devices are supported by this driver, and from which kernel versio
 |   Leakshield   |     Available here     |  Various sensors and setting parameters for higher accuracy  |        ?        |
 | Aquastream XT  |     Available here     | Temperature sensors, voltage sensors, pump and fan speed control | ATMEGA8-16MU |
 | Aquastream Ultimate  |     Available here     | Temperature sensors, pump and fan sensors, pressure and flow | ? |
+| Poweradjust 3  |     Available here     | External temperature sensor | ? |
 
 Microcontrollers are noted for general reference, as this driver only communicates through HID reports and does not interact with the device CPU & electronics directly.
 

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0+
 /*
  * hwmon driver for Aquacomputer devices (D5 Next, Farbwerk, Farbwerk 360, Octo,
- * Quadro, High Flow Next, Aquaero, Leakshield, Aquastream XT, Aquastream Ultimate)
+ * Quadro, High Flow Next, Aquaero, Leakshield, Aquastream XT, Aquastream Ultimate,
+ * Poweradjust 3)
  *
  * Aquacomputer devices send HID reports (with ID 0x01) every second to report
  * sensor values, with the exception of Aquastream XT.

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -584,8 +584,8 @@ struct aqc_data {
 	int temp_sensor_start_offset;
 	int num_virtual_temp_sensors;
 	int virtual_temp_sensor_start_offset;
-	int num_calc_virtual_temp_sensors;
-	int calc_virtual_temp_sensor_start_offset;
+	int num_calc_virt_temp_sensors;
+	int calc_virt_temp_sensor_start_offset;
 	u16 temp_ctrl_offset;
 	u16 power_cycle_count_offset;
 	int num_flow_sensors;
@@ -809,7 +809,7 @@ static umode_t aqc_is_visible(const void *data, enum hwmon_sensor_types type, u3
 
 		if (channel <
 		    priv->num_temp_sensors + priv->num_virtual_temp_sensors +
-		    priv->num_calc_virtual_temp_sensors)
+		    priv->num_calc_virt_temp_sensors)
 			switch (attr) {
 			case hwmon_temp_label:
 			case hwmon_temp_input:
@@ -1706,11 +1706,10 @@ static int aqc_raw_event(struct hid_device *hdev, struct hid_report *report, u8 
 	case aquaero:
 		/* Read calculated virtual temp sensors */
 		i = priv->num_temp_sensors + priv->num_virtual_temp_sensors;
-		for (j = 0; j < priv->num_calc_virtual_temp_sensors; j++) {
+		for (j = 0; j < priv->num_calc_virt_temp_sensors; j++) {
 			sensor_value = get_unaligned_be16(data +
-							  priv->
-							  calc_virtual_temp_sensor_start_offset +
-							  j * AQC_SENSOR_SIZE);
+							  priv->calc_virt_temp_sensor_start_offset
+							  + j * AQC_SENSOR_SIZE);
 			if (sensor_value == AQC_SENSOR_NA)
 				priv->temp_input[i] = -ENODATA;
 			else
@@ -1888,8 +1887,8 @@ static int aqc_probe(struct hid_device *hdev, const struct hid_device_id *id)
 		priv->temp_sensor_start_offset = AQUAERO_SENSOR_START;
 		priv->num_virtual_temp_sensors = AQUAERO_NUM_VIRTUAL_SENSORS;
 		priv->virtual_temp_sensor_start_offset = AQUAERO_VIRTUAL_SENSOR_START;
-		priv->num_calc_virtual_temp_sensors = AQUAERO_NUM_CALC_VIRTUAL_SENSORS;
-		priv->calc_virtual_temp_sensor_start_offset = AQUAERO_CALC_VIRTUAL_SENSOR_START;
+		priv->num_calc_virt_temp_sensors = AQUAERO_NUM_CALC_VIRTUAL_SENSORS;
+		priv->calc_virt_temp_sensor_start_offset = AQUAERO_CALC_VIRTUAL_SENSOR_START;
 		priv->num_flow_sensors = AQUAERO_NUM_FLOW_SENSORS;
 		priv->flow_sensors_start_offset = AQUAERO_FLOW_SENSORS_START;
 

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -2051,7 +2051,13 @@ static int aqc_probe(struct hid_device *hdev, const struct hid_device_id *id)
 
 		priv->num_temp_sensors = AQUASTREAMXT_NUM_SENSORS;
 		priv->temp_sensor_start_offset = AQUASTREAMXT_SENSOR_START;
-		priv->buffer_size = AQUASTREAMXT_SENSOR_REPORT_SIZE;
+
+		/*
+		 * Since we use the same buffer for both sensor and control
+		 * report storage on legacy devices, reserve enough space
+		 */
+		priv->buffer_size = max(AQUASTREAMXT_SENSOR_REPORT_SIZE,
+					AQUASTREAMXT_CTRL_REPORT_SIZE);
 
 		priv->temp_label = label_aquastreamxt_temp_sensors;
 		priv->speed_label = label_d5next_speeds;

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -318,7 +318,7 @@ static u16 aquastreamxt_ctrl_fan_offsets[] = { 0x8, 0x1b };
 
 /* Specs of the Poweradjust 3 */
 #define POWERADJUST3_NUM_SENSORS	1
-#define POWERADJUST3_SENSOR_REPORT_SIZE	50
+#define POWERADJUST3_SENSOR_REPORT_SIZE	0x32
 
 /* Sensor report offsets for the Poweradjust 3 */
 #define POWERADJUST3_SENSOR_START	0x03

--- a/docs/aquacomputer_d5next.rst
+++ b/docs/aquacomputer_d5next.rst
@@ -14,6 +14,7 @@ Supported devices:
 * Aquacomputer High Flow Next sensor
 * Aquacomputer Aquastream XT watercooling pump
 * Aquacomputer Aquastream Ultimate watercooling pump
+* Aquacomputer Poweradjust 3 fan controller
 
 Author: Aleksa Savic
 
@@ -55,6 +56,8 @@ pump and fan and current for the pump.
 The Aquastream Ultimate pump exposes coolant temp and an external temp sensor, along
 with speed, power, voltage and current of both the pump and optionally connected fan.
 It also exposes pressure and flow speed readings.
+
+The Poweradjust 3 controller exposes a single external temperature sensor.
 
 The possible values for pwm_enable are:
 for D5 Next, Quadro and Octo


### PR DESCRIPTION
Add support for the Poweradjust 3 (tested in #57), which communicates through the legacy way, similarly to the Aquastream XT. We currently read one external temp sensor.

Also, refactor the legacy devices reading part: add `sensor_report_id` to `aqc_data` to be able to request the sensor report from the same code.