### PR TITLE
Support for temp-PWM curves and parameters

### DIFF
--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -2135,8 +2135,8 @@ static ssize_t show_curve_start_boost(struct device *dev, struct device_attribut
 	struct aqc_data *priv = dev_get_drvdata(dev);
 	struct sensor_device_attribute *sattr = to_sensor_dev_attr(attr);
 	int index = sattr->index, ret;
-
 	unsigned long val;
+
 	ret = aqc_get_ctrl_val(priv,
 			       priv->fan_curve_hold_start_offsets[index], &val, AQC_8);
 	if (ret < 0)
@@ -2179,8 +2179,8 @@ static ssize_t show_curve_power_hold_min(struct device *dev, struct device_attri
 	struct aqc_data *priv = dev_get_drvdata(dev);
 	struct sensor_device_attribute *sattr = to_sensor_dev_attr(attr);
 	int index = sattr->index, ret;
-
 	unsigned long val;
+
 	ret = aqc_get_ctrl_val(priv,
 			       priv->fan_curve_hold_start_offsets[index], &val, AQC_8);
 	if (ret < 0)
@@ -2230,7 +2230,18 @@ SENSOR_TEMPLATE(curve_power_hold_min, "curve%d_power_min_hold",
 
 static umode_t aqc_params_is_visible(struct kobject *kobj, struct attribute *attr, int index)
 {
-	/* Every fan curve always has all parameters available */
+	/*
+	 * Pump channel on the D5 Next does not support the last two features,
+	 * "start boost" and "hold min power". Every other fan curve supports
+	 * all parameters.
+	 */
+	struct device *dev = kobj_to_dev(kobj);
+	struct aqc_data *priv = dev_get_drvdata(dev);
+	int nr = index % 5;
+
+	if (priv->kind == d5next && nr > 2)
+		return 0;
+
 	return attr->mode;
 }
 

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -1786,15 +1786,20 @@ store_auto_pwm(struct device *dev, struct device_attribute *attr, const char *bu
 	int nr = sattr->nr;
 	int point = sattr->index;
 	unsigned long val;
-	int err;
+	int pwm_value;
 
-	err = kstrtoul(buf, 10, &val);
-	if (err < 0)
-		return err;
+	int ret = kstrtoul(buf, 10, &val);
+	if (ret < 0)
+		return ret;
 	if (val > 255)
 		return -EINVAL;
 
-	/* TODO */
+	pwm_value = aqc_pwm_to_percent(val);
+	ret = aqc_set_ctrl_val(priv,
+			       priv->fan_ctrl_offsets[nr] + AQC_FAN_CTRL_PWM_CURVE_START +
+			       point * AQC_SENSOR_SIZE, pwm_value, AQC_BE16);
+	if (ret < 0)
+		return ret;
 
 	return count;
 }

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -102,8 +102,8 @@ static u8 aquastreamxt_secondary_ctrl_report[] = {
 #define AQC_BE16	1
 #define AQC_LE16	2
 
-#define FAN_CURVE_HOLD_MIN_POWER_POS	1
-#define FAN_CURVE_START_BOOST_POS	2
+#define FAN_CURVE_HOLD_MIN_POWER_BIT_POS	1
+#define FAN_CURVE_START_BOOST_BIT_POS		2
 
 /* Report IDs for legacy devices */
 #define AQUASTREAMXT_STATUS_REPORT_ID	0x04

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -1730,8 +1730,15 @@ static ssize_t show_auto_temp(struct device *dev, struct device_attribute *attr,
 	int nr = sattr->nr;
 	int point = sattr->index;
 
-	/* TODO */
-	return sprintf(buf, "%d\n", 50);
+	unsigned long val;
+	int ret =
+	    aqc_get_ctrl_val(priv,
+			     priv->fan_ctrl_offsets[nr] + AQC_FAN_CTRL_TEMP_CURVE_START +
+			     point * AQC_SENSOR_SIZE, &val, AQC_BE16);
+	if (ret < 0)
+		return -ENODATA;
+
+	return sprintf(buf, "%d\n", (s16)val);
 }
 
 static ssize_t
@@ -2534,8 +2541,7 @@ static int aqc_probe(struct hid_device *hdev, const struct hid_device_id *id)
 	}
 
 	/* Set up curves */
-	/* TODO: Check if required offsets are defined */
-	if (priv->num_fans > 0) {
+	if (priv->fan_ctrl_offsets) {
 		group =
 		    aqc_create_attr_group(&hdev->dev, &aqc_curve_template_group, priv->num_fans);
 		if (IS_ERR(group))

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -924,9 +924,15 @@ static umode_t aqc_is_visible(const void *data, enum hwmon_sensor_types type, u3
 					break;
 				}
 				break;
-			default:
+			case octo:
+			case quadro:
 				switch (attr) {
 				case hwmon_pwm_enable:
+					return 0644;
+				}
+				fallthrough;
+			default:
+				switch (attr) {
 				case hwmon_pwm_input:
 				case hwmon_pwm_auto_channels_temp:
 					return 0644;

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -236,6 +236,26 @@ static u16 octo_sensor_fan_offsets[] = { 0x7D, 0x8A, 0x97, 0xA4, 0xB1, 0xBE, 0xC
 /* Fan speed offsets (0-100%) */
 static u16 octo_ctrl_fan_offsets[] = { 0x5A, 0xAF, 0x104, 0x159, 0x1AE, 0x203, 0x258, 0x2AD };
 
+/* Fan curve "hold min power" and "start boost" offsets */
+static u8 octo_ctrl_fan_curve_hold_start_offsets[] = {
+	0x12, 0x1B, 0x24, 0x2D, 0x36, 0x3F, 0x48, 0x51
+};
+
+/* Fan curve min power */
+static u8 octo_ctrl_fan_curve_min_power_offsets[] = {
+	0x13, 0x1C, 0x25, 0x2E, 0x37, 0x40, 0x49, 0x52
+};
+
+/* Fan curve max power */
+static u8 octo_ctrl_fan_curve_max_power_offsets[] = {
+	0x15, 0x1E, 0x27, 0x30, 0x39, 0x42, 0x4B, 0x54
+};
+
+/* Fan curve fallback power */
+static u8 octo_ctrl_fan_curve_fallback_power_offsets[] = {
+	0x17, 0x20, 0x29, 0x32, 0x3B, 0x44, 0x4D, 0x56
+};
+
 /* Specs of Quadro fan controller */
 #define QUADRO_NUM_FANS			4
 #define QUADRO_NUM_SENSORS		4
@@ -254,6 +274,14 @@ static u16 quadro_sensor_fan_offsets[] = { 0x70, 0x7D, 0x8A, 0x97 };
 #define QUADRO_FLOW_PULSES_CTRL_OFFSET	0x6
 /* Fan speed offsets (0-100%) */
 static u16 quadro_ctrl_fan_offsets[] = { 0x36, 0x8b, 0xe0, 0x135 };
+/* Fan curve "hold min power" and "start boost" offsets */
+static u8 quadro_ctrl_fan_curve_hold_start_offsets[] = { 0x12, 0x1B, 0x24, 0x2D };
+/* Fan curve min power */
+static u8 quadro_ctrl_fan_curve_min_power_offsets[] = { 0x13, 0x1C, 0x25, 0x2E };
+/* Fan curve max power */
+static u8 quadro_ctrl_fan_curve_max_power_offsets[] = { 0x15, 0x1E, 0x27, 0x30 };
+/* Fan curve fallback power */
+static u8 quadro_ctrl_fan_curve_fallback_power_offsets[] = { 0x17, 0x20, 0x29, 0x32 };
 
 /* Specs of High Flow Next flow sensor */
 #define HIGHFLOWNEXT_NUM_SENSORS	2

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -1504,9 +1504,21 @@ static int aqc_write(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 				return -EOPNOTSUPP;
 			}
 
-			/* Decrement to convert from hwmon to aqc */
-			ret = aqc_set_ctrl_val(priv,
-					       priv->fan_ctrl_offsets[channel], val - 1, AQC_8);
+			if (val == 0) {
+				/* Set the fan to 100% as we don't control it anymore */
+				ret =
+				    aqc_set_ctrl_val(priv,
+						     priv->fan_ctrl_offsets[channel] +
+						     AQC_FAN_CTRL_PWM_OFFSET,
+						     aqc_pwm_to_percent(255), AQC_BE16);
+				if (ret < 0)
+					return ret;
+			} else {
+				/* Decrement to convert from hwmon to aqc */
+				val--;
+			}
+
+			ret = aqc_set_ctrl_val(priv, priv->fan_ctrl_offsets[channel], val, AQC_8);
 			if (ret < 0)
 				return ret;
 			break;

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -932,6 +932,7 @@ static umode_t aqc_is_visible(const void *data, enum hwmon_sensor_types type, u3
 					break;
 				}
 				break;
+			case d5next:
 			case octo:
 			case quadro:
 				switch (attr) {
@@ -2887,6 +2888,7 @@ static int aqc_probe(struct hid_device *hdev, const struct hid_device_id *id)
 	/* Set up temp-PWM curves and their parameters for devices that support them */
 	if (priv->fan_ctrl_offsets) {
 		switch (priv->kind) {
+		case d5next:
 		case octo:
 		case quadro:
 			/* Temp-PWM curve */

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -2558,13 +2558,21 @@ static int aqc_probe(struct hid_device *hdev, const struct hid_device_id *id)
 		break;
 	}
 
-	/* Set up curves */
+	/* Set up temp-PWM curves for devices that support them */
 	if (priv->fan_ctrl_offsets) {
-		group =
-		    aqc_create_attr_group(&hdev->dev, &aqc_curve_template_group, priv->num_fans);
-		if (IS_ERR(group))
-			return PTR_ERR(group);
-		priv->groups[groups++] = group;
+		switch (priv->kind) {
+		case octo:
+		case quadro:
+			group =
+			    aqc_create_attr_group(&hdev->dev, &aqc_curve_template_group,
+						  priv->num_fans);
+			if (IS_ERR(group))
+				return PTR_ERR(group);
+			priv->groups[groups++] = group;
+			break;
+		default:
+			break;
+		}
 	}
 
 	if (priv->buffer_size != 0) {

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -186,6 +186,14 @@ static u16 d5next_sensor_fan_offsets[] = { D5NEXT_PUMP_OFFSET, D5NEXT_FAN_OFFSET
 /* Control report offsets for the D5 Next pump */
 #define D5NEXT_TEMP_CTRL_OFFSET		0x2D	/* Temperature sensor offsets location */
 static u16 d5next_ctrl_fan_offsets[] = { 0x96, 0x41 };	/* Pump and fan speed (from 0-100%) */
+/* Fan curve "hold min power" and "start boost" offsets, only for the fan, first value is unused */
+static u8 d5next_ctrl_fan_curve_hold_start_offsets[] = { 0x00, 0x2F };
+/* Fan curve min power */
+static u8 d5next_ctrl_fan_curve_min_power_offsets[] = { 0x39, 0x30 };
+/* Fan curve max power */
+static u8 d5next_ctrl_fan_curve_max_power_offsets[] = { 0x3B, 0x32 };
+/* Fan curve fallback power */
+static u8 d5next_ctrl_fan_curve_fallback_power_offsets[] = { 0x3D, 0x34 };
 
 /* Specs of the Aquastream Ultimate pump */
 /* Pump does not follow the standard structure, so only consider the fan */
@@ -2221,7 +2229,7 @@ SENSOR_TEMPLATE(curve_power_hold_start, "curve%d_power_hold_start",
 
 static umode_t aqc_params_is_visible(struct kobject *kobj, struct attribute *attr, int index)
 {
-	/* Each fan curve always has all parameters available */
+	/* Every fan curve always has all parameters available */
 	return attr->mode;
 }
 
@@ -2636,6 +2644,11 @@ static int aqc_probe(struct hid_device *hdev, const struct hid_device_id *id)
 		priv->num_fans = D5NEXT_NUM_FANS;
 		priv->fan_sensor_offsets = d5next_sensor_fan_offsets;
 		priv->fan_ctrl_offsets = d5next_ctrl_fan_offsets;
+		priv->fan_curve_min_power_offsets = d5next_ctrl_fan_curve_min_power_offsets;
+		priv->fan_curve_max_power_offsets = d5next_ctrl_fan_curve_max_power_offsets;
+		priv->fan_curve_hold_start_offsets = d5next_ctrl_fan_curve_hold_start_offsets;
+		priv->fan_curve_fallback_power_offsets =
+		    d5next_ctrl_fan_curve_fallback_power_offsets;
 
 		priv->num_temp_sensors = D5NEXT_NUM_SENSORS;
 		priv->temp_sensor_start_offset = D5NEXT_COOLANT_TEMP;

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -252,17 +252,14 @@ static u8 octo_ctrl_fan_curve_hold_start_offsets[] = {
 	0x12, 0x1B, 0x24, 0x2D, 0x36, 0x3F, 0x48, 0x51
 };
 
-/* Fan curve min power */
 static u8 octo_ctrl_fan_curve_min_power_offsets[] = {
 	0x13, 0x1C, 0x25, 0x2E, 0x37, 0x40, 0x49, 0x52
 };
 
-/* Fan curve max power */
 static u8 octo_ctrl_fan_curve_max_power_offsets[] = {
 	0x15, 0x1E, 0x27, 0x30, 0x39, 0x42, 0x4B, 0x54
 };
 
-/* Fan curve fallback power */
 static u8 octo_ctrl_fan_curve_fallback_power_offsets[] = {
 	0x17, 0x20, 0x29, 0x32, 0x3B, 0x44, 0x4D, 0x56
 };
@@ -287,11 +284,8 @@ static u16 quadro_sensor_fan_offsets[] = { 0x70, 0x7D, 0x8A, 0x97 };
 static u16 quadro_ctrl_fan_offsets[] = { 0x36, 0x8b, 0xe0, 0x135 };
 /* Fan curve "hold min power" and "start boost" offsets */
 static u8 quadro_ctrl_fan_curve_hold_start_offsets[] = { 0x12, 0x1B, 0x24, 0x2D };
-/* Fan curve min power */
 static u8 quadro_ctrl_fan_curve_min_power_offsets[] = { 0x13, 0x1C, 0x25, 0x2E };
-/* Fan curve max power */
 static u8 quadro_ctrl_fan_curve_max_power_offsets[] = { 0x15, 0x1E, 0x27, 0x30 };
-/* Fan curve fallback power */
 static u8 quadro_ctrl_fan_curve_fallback_power_offsets[] = { 0x17, 0x20, 0x29, 0x32 };
 
 /* Specs of High Flow Next flow sensor */
@@ -2142,7 +2136,7 @@ static ssize_t show_curve_start_boost(struct device *dev, struct device_attribut
 	if (ret < 0)
 		return -ENODATA;
 
-	return sprintf(buf, "%d\n", aqc_get_bit_at_pos(val, FAN_CURVE_START_BOOST_POS));
+	return sprintf(buf, "%d\n", aqc_get_bit_at_pos(val, FAN_CURVE_START_BOOST_BIT_POS));
 }
 
 static ssize_t
@@ -2164,7 +2158,7 @@ store_curve_start_boost(struct device *dev, struct device_attribute *attr, const
 	if (ret < 0)
 		return ret;
 
-	new_val = aqc_set_bit_at_pos(new_val, FAN_CURVE_START_BOOST_POS, val);
+	new_val = aqc_set_bit_at_pos(new_val, FAN_CURVE_START_BOOST_BIT_POS, val);
 
 	ret = aqc_set_ctrl_val(priv, priv->fan_curve_hold_start_offsets[index], new_val, AQC_8);
 	if (ret < 0)
@@ -2186,7 +2180,7 @@ static ssize_t show_curve_power_hold_min(struct device *dev, struct device_attri
 	if (ret < 0)
 		return -ENODATA;
 
-	return sprintf(buf, "%d\n", aqc_get_bit_at_pos(val, FAN_CURVE_HOLD_MIN_POWER_POS));
+	return sprintf(buf, "%d\n", aqc_get_bit_at_pos(val, FAN_CURVE_HOLD_MIN_POWER_BIT_POS));
 }
 
 static ssize_t
@@ -2208,7 +2202,7 @@ store_curve_power_hold_min(struct device *dev, struct device_attribute *attr, co
 	if (ret < 0)
 		return ret;
 
-	new_val = aqc_set_bit_at_pos(new_val, FAN_CURVE_HOLD_MIN_POWER_POS, val);
+	new_val = aqc_set_bit_at_pos(new_val, FAN_CURVE_HOLD_MIN_POWER_BIT_POS, val);
 
 	ret = aqc_set_ctrl_val(priv, priv->fan_curve_hold_start_offsets[index], new_val, AQC_8);
 	if (ret < 0)

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -2173,8 +2173,8 @@ store_curve_start_boost(struct device *dev, struct device_attribute *attr, const
 	return count;
 }
 
-static ssize_t show_curve_power_hold_start(struct device *dev, struct device_attribute *attr,
-					   char *buf)
+static ssize_t show_curve_power_hold_min(struct device *dev, struct device_attribute *attr,
+					 char *buf)
 {
 	struct aqc_data *priv = dev_get_drvdata(dev);
 	struct sensor_device_attribute *sattr = to_sensor_dev_attr(attr);
@@ -2190,8 +2190,8 @@ static ssize_t show_curve_power_hold_start(struct device *dev, struct device_att
 }
 
 static ssize_t
-store_curve_power_hold_start(struct device *dev, struct device_attribute *attr, const char *buf,
-			     size_t count)
+store_curve_power_hold_min(struct device *dev, struct device_attribute *attr, const char *buf,
+			   size_t count)
 {
 	struct aqc_data *priv = dev_get_drvdata(dev);
 	struct sensor_device_attribute *sattr = to_sensor_dev_attr(attr);
@@ -2225,8 +2225,8 @@ SENSOR_TEMPLATE(curve_power_fallback, "curve%d_power_fallback",
 		0644, show_curve_power_fallback, store_curve_power_fallback, 0);
 SENSOR_TEMPLATE(curve_start_boost, "curve%d_start_boost",
 		0644, show_curve_start_boost, store_curve_start_boost, 0);
-SENSOR_TEMPLATE(curve_power_hold_start, "curve%d_power_hold_start",
-		0644, show_curve_power_hold_start, store_curve_power_hold_start, 0);
+SENSOR_TEMPLATE(curve_power_hold_min, "curve%d_power_min_hold",
+		0644, show_curve_power_hold_min, store_curve_power_hold_min, 0);
 
 static umode_t aqc_params_is_visible(struct kobject *kobj, struct attribute *attr, int index)
 {
@@ -2239,7 +2239,7 @@ static struct sensor_device_template *aqc_attributes_params_template[] = {
 	&sensor_dev_template_curve_power_max,
 	&sensor_dev_template_curve_power_fallback,
 	&sensor_dev_template_curve_start_boost,
-	&sensor_dev_template_curve_power_hold_start,
+	&sensor_dev_template_curve_power_hold_min,
 	NULL
 };
 

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -1749,13 +1749,16 @@ store_auto_temp(struct device *dev, struct device_attribute *attr, const char *b
 	int nr = sattr->nr;
 	int point = sattr->index;
 	unsigned long val;
-	int err;
+	int ret = kstrtoul(buf, 10, &val);
 
-	err = kstrtoul(buf, 10, &val);
-	if (err)
-		return err;
-	if (val > 255000)	/* TODO */
-		return -EINVAL;
+	if (ret < 0)
+		return ret;
+
+	ret = aqc_set_ctrl_val(priv,
+			       priv->fan_ctrl_offsets[nr] + AQC_FAN_CTRL_TEMP_CURVE_START +
+			       point * AQC_SENSOR_SIZE, val, AQC_BE16);
+	if (ret < 0)
+		return ret;
 
 	return count;
 }
@@ -1789,6 +1792,7 @@ store_auto_pwm(struct device *dev, struct device_attribute *attr, const char *bu
 	int pwm_value;
 
 	int ret = kstrtoul(buf, 10, &val);
+
 	if (ret < 0)
 		return ret;
 	if (val > 255)

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -120,10 +120,13 @@ static u8 aquastreamxt_secondary_ctrl_report[] = {
 #define AQC_FAN_CURRENT_OFFSET		0x04
 #define AQC_FAN_POWER_OFFSET		0x06
 #define AQC_FAN_SPEED_OFFSET		0x08
+#define AQC_FAN_CTRL_CURVE_NUM_POINTS	16
 
 /* Report offsets for fan control */
 #define AQC_FAN_CTRL_PWM_OFFSET		0x01
 #define AQC_FAN_CTRL_TEMP_SELECT_OFFSET	0x03
+#define AQC_FAN_CTRL_TEMP_CURVE_START	0x15
+#define AQC_FAN_CTRL_PWM_CURVE_START	0x35
 
 /* Specs of the Aquaero fan controllers */
 #define AQUAERO_SERIAL_START			0x07
@@ -1862,12 +1865,7 @@ SENSOR_TEMPLATE_2(temp_auto_point16_temp, "temp%d_auto_point16_temp",
 
 static umode_t aqc_curve_is_visible(struct kobject *kobj, struct attribute *attr, int index)
 {
-	struct device *dev = kobj_to_dev(kobj);
-	struct aqc_data *data = dev_get_drvdata(dev);
-	int pwm = index;	/* pwm index */
-
-	/* TODO */
-
+	/* Each fan always has 16 points available */
 	return attr->mode;
 }
 

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -2219,7 +2219,7 @@ SENSOR_TEMPLATE(curve_power_fallback, "curve%d_power_fallback",
 		0644, show_curve_power_fallback, store_curve_power_fallback, 0);
 SENSOR_TEMPLATE(curve_start_boost, "curve%d_start_boost",
 		0644, show_curve_start_boost, store_curve_start_boost, 0);
-SENSOR_TEMPLATE(curve_power_hold_min, "curve%d_power_min_hold",
+SENSOR_TEMPLATE(curve_power_hold_min, "curve%d_power_hold_min",
 		0644, show_curve_power_hold_min, store_curve_power_hold_min, 0);
 
 static umode_t aqc_params_is_visible(struct kobject *kobj, struct attribute *attr, int index)

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -1764,9 +1764,18 @@ static ssize_t show_auto_pwm(struct device *dev, struct device_attribute *attr, 
 {
 	struct aqc_data *priv = dev_get_drvdata(dev);
 	struct sensor_device_attribute_2 *sattr = to_sensor_dev_attr_2(attr);
+	int nr = sattr->nr;
+	int point = sattr->index;
 
-	/* TODO */
-	return sprintf(buf, "test\n");
+	unsigned long val;
+	int ret =
+	    aqc_get_ctrl_val(priv,
+			     priv->fan_ctrl_offsets[nr] + AQC_FAN_CTRL_PWM_CURVE_START +
+			     point * AQC_SENSOR_SIZE, &val, AQC_BE16);
+	if (ret < 0)
+		return -ENODATA;
+
+	return sprintf(buf, "%d\n", aqc_percent_to_pwm(val));
 }
 
 static ssize_t


### PR DESCRIPTION
The end goal of this PR is to add support for temp-PWM curves for fans, along with other custom parameters that can be set from Aquasuite regarding the curves.

I found that nct6683 and nct6775 solved the problem of having many fans, and subsequently, many unwieldy macro definitions. There, the problem is solved by creating a template curve with points, which is defined once. Then, real curves are generated from that template as many times as needed. I remixed that code here with attribution.

Closes #14, closes #1, closes #2.

TODO:

- [x] Restrict what devices have the curves available
- [x] Implement D5 Next ctrl offsets
- [x] Add support for min/max power, "use start boost" etc.
- [ ] Add support for PID mode (perhaps in a separate PR)
- [x] Add additional explanations for some macros
- [x] Set fan to 100% when 0 is written to pwmX_enable
- [x] Try to disable showing entries unavailable on the D5 Next for it
- [x] Remove superfluous comments
- [x] POS macro comment/rename?