### PR TITLE
Fix reading pwm_input for d5_next, octo and quadro

### DIFF
--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -1169,9 +1169,8 @@ static int aqc_read(struct device *dev, enum hwmon_sensor_types type, u32 attr,
 			default:
 				ret =
 				    aqc_get_ctrl_val(priv,
-						     AQUAERO_CTRL_PRESET_START +
-						     channel * AQUAERO_CTRL_PRESET_SIZE,
-						     val, AQC_BE16);
+						     priv->fan_ctrl_offsets[channel] +
+						     AQC_FAN_CTRL_PWM_OFFSET, val, AQC_BE16);
 				if (ret < 0)
 					return ret;
 				*val = aqc_percent_to_pwm(*val);


### PR DESCRIPTION
This error was introduced in 1af5215f2e1755c069d255379c0666acc09034b8

Signed-off-by: Leonard Anderweit <leonard.anderweit@gmail.com>