### PR TITLE
Add support for reading Aquabus sensors on Aquaero

### DIFF
--- a/docs/aquacomputer_d5next.rst
+++ b/docs/aquacomputer_d5next.rst
@@ -30,6 +30,10 @@ along with their speed (in RPM), power, voltage and current. The PWM fans can be
 controlled directly and can be configured as DC or PWM using pwm[1-4]_mode. Note
 that Aquaero 5 can set PWM mode only for the fourth fan.
 
+Additionally, Aquaero devices also expose twenty temperature sensors and twelve flow
+sensors from devices connected via Aquabus. The assigned sensor number is
+predetermined by the Aquabus address of the device.
+
 For the D5 Next pump, available sensors are pump and fan speed, power, voltage
 and current, as well as coolant temperature. Also available through debugfs are
 the serial number, firmware version and power-on count. Attaching a fan to it is
@@ -107,9 +111,9 @@ Sysfs entries
 -------------
 
 =========================== ==============================================================
-temp[1-20]_input            Physical/virtual temperature sensors (in millidegrees Celsius)
+temp[1-40]_input            Physical/virtual temperature sensors (in millidegrees Celsius)
 temp[1-4]_offset            Temperature sensor correction offset (in millidegrees Celsius)
-fan[1-8]_input              Pump/fan speed (in RPM) / Flow speed (in dL/h)
+fan[1-20]_input             Pump/fan speed (in RPM) / Flow speed (in dL/h)
 fan5_pulses                 Quadro flow sensor pulses
 power[1-8]_input            Pump/fan power (in micro Watts)
 in[0-7]_input               Pump/fan voltage (in milli Volts)


### PR DESCRIPTION
### Checklist:

- [x] My code follows Linux code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes on the affected device(s) 
  - Aquaero 6 LT with the Aquabus readings from:
    - D5 Next
    - Highflow Next

---

Add support for reading Aquabus sensors on Aquaero. Aquaero exposes an additional 20 temperature sensors, 12 flow sensors, 2 pumps, and 4 fans via Aquabus. This allows these sensors to be read without having Aquabus devices connected to the host via USB.

In this PR, I've implemented 20 temperature sensors, and 12 flow sensors reading. Pump speed is left out for now, as I couldn't figure out the offset of the second pump. Fan reading is also left out, as I currently do not have fans connected to devices on Aquabus. 

Tested comparing temperature sensor of D5 Next and Highflow Next via USB and via Aquabus and the value matches. The flow sensor also matches that of High Flow Next. The sensor number also matches the number in Aquasuite.

(For a reference: first pump is at 0x01f9, voltage is at 0x01fb, and current is 0x01fd respectively, but I'm uncertain beyond that point.)