### PR TITLE
Fix -EPIPE/-ENODATA errors after writing to sysfs entries in quick succession

### DIFF
--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -845,10 +845,19 @@ static int aqc_send_ctrl_data(struct aqc_data *priv)
 	 * quick succession (for example, setting pwmX_enable and pwmX attributes at once).
 	 *
 	 * 200ms was found to be the sweet spot between fixing the issue and not significantly
-	 * prolonging the call. Quadro, Octo and Aquaero are currently known to be affected.
+	 * prolonging the call. Quadro, Octo, D5 Next and Aquaero are currently known to be
+	 * affected.
 	 */
-	if (priv->kind == quadro || priv->kind == octo || priv->kind == aquaero)
+	switch (priv->kind) {
+	case quadro:
+	case octo:
+	case d5next:
+	case aquaero:
 		msleep(200);
+		break;
+	default:
+		break;
+	}
 
 	return ret;
 }


### PR DESCRIPTION
### Checklist:

- [x] My code follows Linux code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes on the affected device(s)

---
Fixes #82.