### PR TITLE
Add temp offset support for farbwerk

### DIFF
--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -225,6 +225,10 @@ static u16 aquastreamult_sensor_fan_offsets[] = { AQUASTREAMULT_FAN_OFFSET };
 /* Spec and sensor report offset for the Farbwerk RGB controller */
 #define FARBWERK_NUM_SENSORS		4
 #define FARBWERK_SENSOR_START		0x2f
+#define FARBWERK_CTRL_REPORT_SIZE	0xea
+
+/* Control report offsets for the Farbwerk */
+#define FARBWERK_TEMP_CTRL_OFFSET	9
 
 /* Specs of the Farbwerk 360 RGB controller */
 #define FARBWERK360_NUM_SENSORS			4
@@ -2865,7 +2869,8 @@ static int aqc_probe(struct hid_device *hdev, const struct hid_device_id *id)
 		priv->num_temp_sensors = FARBWERK_NUM_SENSORS;
 		priv->temp_sensor_start_offset = FARBWERK_SENSOR_START;
 
-		priv->temp_ctrl_offset = 0;
+		priv->buffer_size = FARBWERK_CTRL_REPORT_SIZE;
+		priv->temp_ctrl_offset = FARBWERK_TEMP_CTRL_OFFSET;
 
 		priv->temp_label = label_temp_sensors;
 		break;


### PR DESCRIPTION
Addresses #27 

I don't own a farbwerk, so I can't/haven't tested this, I just found the start offset in Aquasuite and confirmed the offsets are sequential. I also took a stab at calculating the control report size, but without pcaps from real hardware, it's just a guess.

### Checklist:

- [x] My code follows Linux code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have tested my changes on the affected device(s) - note on which
