### PR TITLE
Sync main with upstream and use kernel v6.4 for CI

### DIFF
--- a/.github/workflows/compile-driver.yaml
+++ b/.github/workflows/compile-driver.yaml
@@ -13,7 +13,7 @@
         with:
           repository: torvalds/linux
           path: ./linux
-          ref:  v6.2
+          ref:  v6.4
       - name: install libelf-dev
         run: |
           sudo apt update
@@ -24,4 +24,4 @@
           make x86_64_defconfig
           make modules_prepare
       - name: compile driver
-        run: make -C ./linux M=$PWD modules
+        run: KBUILD_MODPOST_WARN=1 make -C ./linux M=$PWD modules

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -2350,7 +2350,7 @@ static const struct hwmon_ops aqc_hwmon_ops = {
 	.write = aqc_write
 };
 
-static const struct hwmon_channel_info *aqc_info[] = {
+static const struct hwmon_channel_info * const aqc_info[] = {
 	HWMON_CHANNEL_INFO(temp,
 			   HWMON_T_INPUT | HWMON_T_LABEL | HWMON_T_OFFSET,
 			   HWMON_T_INPUT | HWMON_T_LABEL | HWMON_T_OFFSET,


### PR DESCRIPTION
### Checklist:

- [x] My code follows Linux code style guidelines
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have tested my changes on the affected device(s) - note on which

There is a new commit upstream which requires at least kernel v6.4 to work.