### PR TITLE
Add support for Octo flow sensor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,21 +2,24 @@
 
 # external KDIR specification is supported
 KDIR ?= /lib/modules/$(shell uname -r)/build
+PWD ?= $(shell pwd)
 
 SOURCES := aquacomputer_d5next.c docs/aquacomputer_d5next.rst
+
+.PHONY: all modules modules clean checkpatch dev
 
 all: modules
 
 install: modules_install
 
 modules modules_install clean:
-	make -C $(KDIR) M=$$PWD $@
+	$(MAKE) -C $(KDIR) M=$(PWD) $@
 
 checkpatch:
 	$(KDIR)/scripts/checkpatch.pl --strict --no-tree $(SOURCES)
 
 dev:
-	make clean
-	make
+	$(MAKE) clean
+	$(MAKE)
 	sudo rmmod aquacomputer_d5next || true
 	sudo insmod aquacomputer_d5next.ko

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -1106,9 +1106,15 @@ static umode_t aqc_is_visible(const void *data, enum hwmon_sensor_types type, u3
 			break;
 		case hwmon_fan_pulses:
 			/* Special case for Quadro/Octo flow sensor */
-			if ((priv->kind == quadro || priv->kind == octo) &&
-			    channel == priv->num_fans)
-				return 0644;
+			if (channel == priv->num_fans) {
+				switch (priv->kind) {
+				case quadro:
+				case octo:
+					return 0644;
+				default:
+					break;
+				}
+			}
 			break;
 		default:
 			break;

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -2449,7 +2449,7 @@ static const struct hwmon_channel_info * const aqc_info[] = {
 			   HWMON_F_INPUT | HWMON_F_LABEL,
 			   HWMON_F_INPUT | HWMON_F_LABEL,
 			   HWMON_F_INPUT | HWMON_F_LABEL,
-			   HWMON_F_INPUT | HWMON_F_LABEL,
+			   HWMON_F_INPUT | HWMON_F_LABEL | HWMON_F_PULSES,
 			   HWMON_F_INPUT | HWMON_F_LABEL,
 			   HWMON_F_INPUT | HWMON_F_LABEL,
 			   HWMON_F_INPUT | HWMON_F_LABEL,

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -253,7 +253,7 @@ static u16 aquastreamult_sensor_fan_offsets[] = { AQUASTREAMULT_FAN_OFFSET };
 /* Sensor report offsets for the Octo */
 #define OCTO_SENSOR_START		0x3D
 #define OCTO_VIRTUAL_SENSORS_START	0x45
-#define OCTO_FLOW_SENSOR_OFFSET	0x7B
+#define OCTO_FLOW_SENSOR_OFFSET		0x7B
 static u16 octo_sensor_fan_offsets[] = { 0x7D, 0x8A, 0x97, 0xA4, 0xB1, 0xBE, 0xCB, 0xD8 };
 
 /* Control report offsets for the Octo */

--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -854,8 +854,6 @@ static int aqc_get_ctrl_data(struct aqc_data *priv)
 	if (ret < 0)
 		ret = -ENODATA;
 
-	print_hex_dump_bytes("ctrl_report: ", DUMP_PREFIX_OFFSET, priv->buffer, priv->buffer_size);
-
 	priv->last_ctrl_report_op = ktime_get();
 
 	return ret;
@@ -1196,8 +1194,6 @@ static int aqc_legacy_read(struct aqc_data *priv)
 				 priv->buffer_size, HID_FEATURE_REPORT, HID_REQ_GET_REPORT);
 	if (ret < 0)
 		goto unlock_and_return;
-
-	print_hex_dump_bytes("ctrl_report: ", DUMP_PREFIX_OFFSET, priv->buffer, priv->buffer_size);
 
 	/* Temperature sensor readings */
 	for (i = 0; i < priv->num_temp_sensors; i++) {
@@ -2521,8 +2517,6 @@ static int aqc_raw_event(struct hid_device *hdev, struct hid_report *report, u8 
 
 	if (report->id != STATUS_REPORT_ID)
 		return 0;
-
-	print_hex_dump_bytes("status_report: ", DUMP_PREFIX_OFFSET, data, size);
 
 	priv = hid_get_drvdata(hdev);
 

--- a/docs/aquacomputer_d5next.rst
+++ b/docs/aquacomputer_d5next.rst
@@ -115,6 +115,7 @@ fan[1-4]_min                    Minimal fan speed (in RPM)
 fan[1-4]_max                    Maximal fan speed (in RPM)
 fan1_target                     Target fan speed (in RPM)
 fan5_pulses                     Quadro flow sensor pulses
+fan9_pulses                     Octo flow sensor pulses
 power[1-8]_input                Pump/fan power (in micro Watts)
 in[0-7]_input                   Pump/fan voltage (in milli Volts)
 curr[1-8]_input                 Pump/fan current (in milli Amperes)

--- a/docs/aquacomputer_d5next.rst
+++ b/docs/aquacomputer_d5next.rst
@@ -48,7 +48,7 @@ via its physical interface.
 
 The Octo exposes four physical and sixteen virtual temperature sensors, as well as
 eight PWM controllable fans, along with their speed (in RPM), power, voltage and
-current.
+current. Flow sensor pulses are also available.
 
 The Quadro exposes four physical and sixteen virtual temperature sensors, a flow
 sensor and four PWM controllable fans, along with their speed (in RPM), power,

--- a/re-docs/PROTOCOLS.md
+++ b/re-docs/PROTOCOLS.md
@@ -191,6 +191,7 @@ Here is what it's currently known to contain:
 | Fan 6 substructure                 | 0xBE                     |
 | Fan 7 substructure                 | 0xCB                     |
 | Fan 8 substructure                 | 0xD8                     |
+| Flow sensor                        | 0x7B                     |
 | Virtual temp sensor 1              | 0x45                     |
 | Virtual temp sensor 2              | 0x47                     |
 | Virtual temp sensor 3              | 0x49                     |
@@ -231,6 +232,7 @@ Here is what it's currently known to contain:
 | Fan 7 ctrl substructure                      | 0x258                                            |
 | Fan 8 ctrl substructure                      | 0x2AD                                            |
 | Temp offset ctrl substructure                | 0xA                                              |
+| Flow sensors pulses                          | 0x6                                              |
 | Fan curve "hold min power" and "start boost" | {0x12, 0x1B, 0x24, 0x2D, 0x36, 0x3F, 0x48, 0x51} |
 | Fan curve min power subgroup                 | {0x13, 0x1C, 0x25, 0x2E, 0x37, 0x40, 0x49, 0x52} |
 | Fan curve max power subgroup                 | {0x15, 0x1E, 0x27, 0x30, 0x39, 0x42, 0x4B, 0x54} |


### PR DESCRIPTION
Adds support for the Octo flow sensor.  I have tested with a real Octo device that's installed on my system, and compared the reported value to what the official Aquasuite app reports (which is easy to do by launching Aquasuite in a VM and re-directing the USB device to/from the VM quickly)

I'm not sure how the pulses ctrl register is supposed to work and how to test it reliably, so I copied over the behavior from Quadro for now.  Any advice appreciated on how to test this interaction using my hardware!

I'll update docs and such once I have a better understanding of the ctrl register situation!

Fixes #6.

### Checklist:

- [x] My code follows Linux code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes on the affected device(s) - note on which
- [x] All exposed values are being read from the device
