### PR TITLE
Add support for D5Next flow sensor

### DIFF
--- a/aquacomputer_d5next.c
+++ b/aquacomputer_d5next.c
@@ -191,10 +191,12 @@ static u16 aquaero_ctrl_fan_offsets[] = { 0x20c, 0x220, 0x234, 0x248 };
 #define D5NEXT_NUM_FANS			2
 #define D5NEXT_NUM_SENSORS		1
 #define D5NEXT_NUM_VIRTUAL_SENSORS	8
+#define D5NEXT_NUM_FLOW_SENSORS		1
 #define D5NEXT_CTRL_REPORT_SIZE		0x329
 
 /* Sensor report offsets for the D5 Next pump */
 #define D5NEXT_COOLANT_TEMP		0x57
+#define D5NEXT_FLOW_SENSOR_OFFSET	0x59
 #define D5NEXT_PUMP_OFFSET		0x6c
 #define D5NEXT_FAN_OFFSET		0x5f
 #define D5NEXT_5V_VOLTAGE		0x39
@@ -417,7 +419,8 @@ static const char *const label_d5next_temp[] = {
 
 static const char *const label_d5next_speeds[] = {
 	"Pump speed",
-	"Fan speed"
+	"Fan speed",
+	"Flow speed [dL/h]"
 };
 
 static const char *const label_d5next_power[] = {
@@ -1108,6 +1111,7 @@ static umode_t aqc_is_visible(const void *data, enum hwmon_sensor_types type, u3
 			case aquaero:
 			case quadro:
 			case octo:
+			case d5next:
 			case highflow:
 			case poweradjust3:
 				/* Special case to support flow sensors */
@@ -2943,6 +2947,8 @@ static int aqc_probe(struct hid_device *hdev, const struct hid_device_id *id)
 		priv->temp_sensor_start_offset = D5NEXT_COOLANT_TEMP;
 		priv->num_virtual_temp_sensors = D5NEXT_NUM_VIRTUAL_SENSORS;
 		priv->virtual_temp_sensor_start_offset = D5NEXT_VIRTUAL_SENSORS_START;
+		priv->num_flow_sensors = D5NEXT_NUM_FLOW_SENSORS;
+		priv->flow_sensors_start_offset = D5NEXT_FLOW_SENSOR_OFFSET;
 
 		priv->power_cycle_count_offset = AQC_POWER_CYCLES;
 		priv->buffer_size = D5NEXT_CTRL_REPORT_SIZE;

--- a/re-docs/PROTOCOLS.md
+++ b/re-docs/PROTOCOLS.md
@@ -76,6 +76,7 @@ Here is what it's currently known to contain:
 | Firmware version                   | 0xD                      |
 | Number of power cycles *[4 bytes]* | 0x18                     |
 | Liquid (water) temperature         | 0x57                     |
+| Flow sensor                        | 0x59                     |
 | Pump info substructure             | 0x74                     |
 | Fan info substructure              | 0x67                     |
 | +5V voltage                        | 0x39                     |


### PR DESCRIPTION
Changes were tested on D5 Next pump with High Flow sensor connected to FAN/FLOW port. I used wireshark to observe hid data from the pump and compared it with what the pump display showed. The value is correct and updates properly when pump power is changed.

The same flow value is reported at offset 0x59 and 0x5B. I am not sure why. Maybe it has something to do with virtual flow sensor that D5 Next offers? 

![image](https://github.com/user-attachments/assets/b6086ebe-ed0b-49e5-a73e-8b6783c5ff72)

### Checklist:

- [x] My code follows Linux code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes on the affected device(s) - note on which
- [x] All exposed values are being read from the device
